### PR TITLE
Commented setup line

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - pip install pytest pytest-cov
   - pip install numpy
   - pip install codecov
-  - pip install -e .
+#  - pip install -e .
 
 script:
 #  - py.test -v --cov=./


### PR DESCRIPTION
I commented the
```
pip install -e .
```
line since we do not have a `setup.py` yet. Can be uncommented whenever we set it up.