### PR TITLE
Construct the overall structure module (issue #19)

### DIFF
--- a/scf/__init__.py
+++ b/scf/__init__.py
@@ -4,5 +4,6 @@ Initializes everything for the SCF program.
 
 
 # import the HF driver
-from . import hf
-from .hf import *
+from .init import *
+from .run import *
+from .clean import *

--- a/scf/clean.py
+++ b/scf/clean.py
@@ -1,0 +1,9 @@
+"""
+Clean up.
+"""
+
+
+def clean():
+    """
+    """
+    pass

--- a/scf/init.py
+++ b/scf/init.py
@@ -1,0 +1,11 @@
+"""
+Initializations for scf calculations:
+    - preparing integrals
+    - parsing & packing parameters
+"""
+
+
+def init():
+    """
+    """
+    pass

--- a/scf/run.py
+++ b/scf/run.py
@@ -1,0 +1,10 @@
+"""
+Take everything from init (e.g. integrals, packed parameters)
+and do the calculations
+"""
+
+
+def run():
+    """
+    """
+    pass

--- a/scf/scf.py
+++ b/scf/scf.py
@@ -3,6 +3,7 @@ The Hartree-Fock driver.
 Performs a Hartree-Fock calculation on a given molecule.
 """
 
+
 def energy():
     """
     Calculates the energy.

--- a/scf/scf.py
+++ b/scf/scf.py
@@ -4,6 +4,53 @@ Performs a Hartree-Fock calculation on a given molecule.
 """
 
 
+def scf(ao_int, scf_params):
+    """
+    Solve the SCF problem given AO integrals (ao_int [dict]):
+        - T: ao_kinetic
+        - V: ao_potential
+        - g: ao_eri
+        - S: ao_overlap
+        - A: S^(-1/2)
+    and parameters for SCF (scf_params [dict]):
+        - nel   [int]   # of electrons
+                        CHECK: non-negative, even integer
+
+        - nbas  [int]   # of basis functions
+                        CHECK: 1. positive integer
+                               2. consistent w/ T, V, g, ...
+
+        - conv  [int]   convg threshold (10E-conv) for ||[F, D]||
+                        CHECK: positive integer less than 14
+
+        - opt   [str]   optimizer to accelerate SCF (case insensitive)
+                        CHECK: must be from ['damping', 'diis', 'direct']
+
+        - max_nbf[int]  max # of basis functions (for memory concerned)
+
+        - guess [str]   initial guess (currently only "core" is supported)
+    """
+    # unpack ao_int
+    T = ao_int['T']
+    V = ao_int['V']
+    g = ao_int['g']
+    S = ao_int['S']
+    A = ao_int['A']
+
+    # build Hcore (T and V are not needed in scf)
+    Hcore = T + V
+
+    # unpack scf_params
+    nel = scf_params['nel']
+    nbas = scf_params['nbas']
+    conv = 10. ** (-scf_params['conv'])
+    opt = scf_params['opt']
+    max_nbf = scf_params['mat_nbf']
+    guess = scf_params['core']
+
+    # initial guess
+
+
 def energy():
     """
     Calculates the energy.


### PR DESCRIPTION
close #19 

note that I've changed `hf.py` to `scf.py`

Users can use our program by:
```
import scf
scf.init(...)
scf.run(...)
scf.clean(...)
```

I don't know why this new PR is put together w/ previous PR's.
Anyway the newest one should close #36 