### PR TITLE
Adds the cpp version of getJK_np

### DIFF
--- a/jk/CMakeLists.txt
+++ b/jk/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+project(molssi_sss_pybind)
+
+# This must be run using a conda environment
+if("$ENV{CONDA_PREFIX}" STREQUAL "")
+    message(FATAL_ERROR "This must be run within the MolSSI SSS conda prefix. "
+                        "Delete the build directory and try again")
+endif()
+
+# CMake will sometimes find the conda python version
+# (rather the the python inside the sss environment)
+set(PYTHON_EXECUTABLE $ENV{CONDA_PREFIX}/bin/python3)
+
+# Find the pybind11 in the conda path
+set(PYBIND11_CPP_STANDARD -std=c++11)
+find_package(pybind11 CONFIG REQUIRED
+             PATHS $ENV{CONDA_PREFIX}
+             NO_DEFAULT_PATH)
+
+message(STATUS "Found pybind11: ${pybind11_CONFIG}")
+
+# Creates a python module named "module_name"
+# pybind11_add_module(module_name MODULE file1.cpp file2.cpp)
+pybind11_add_module(jk MODULE jk.cpp)

--- a/jk/CMakeLists.txt
+++ b/jk/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 set(PYTHON_EXECUTABLE $ENV{CONDA_PREFIX}/bin/python3)
 
 # CXX flags
-set (CMAKE_CXX_FLAGS "-Ofast -fopt-info -funroll-loops -fopenmp")
+set (CMAKE_CXX_FLAGS "-Ofast -lmkl_intel_lp64 -lmkl_sequential -lmkl_core")
 
 # Find the pybind11 in the conda path
 set(PYBIND11_CPP_STANDARD -std=c++11)

--- a/jk/CMakeLists.txt
+++ b/jk/CMakeLists.txt
@@ -11,6 +11,9 @@ endif()
 # (rather the the python inside the sss environment)
 set(PYTHON_EXECUTABLE $ENV{CONDA_PREFIX}/bin/python3)
 
+# CXX flags
+set (CMAKE_CXX_FLAGS "-Ofast")
+
 # Find the pybind11 in the conda path
 set(PYBIND11_CPP_STANDARD -std=c++11)
 find_package(pybind11 CONFIG REQUIRED

--- a/jk/CMakeLists.txt
+++ b/jk/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 set(PYTHON_EXECUTABLE $ENV{CONDA_PREFIX}/bin/python3)
 
 # CXX flags
-set (CMAKE_CXX_FLAGS "-Ofast")
+set (CMAKE_CXX_FLAGS "-Ofast -fopt-info -funroll-loops -fopenmp")
 
 # Find the pybind11 in the conda path
 set(PYBIND11_CPP_STANDARD -std=c++11)

--- a/jk/__init__.py
+++ b/jk/__init__.py
@@ -1,0 +1,7 @@
+"""
+Initializes everything for the jk module.
+"""
+
+
+# import the HF driver
+from .jk import *

--- a/jk/build/scf.py
+++ b/jk/build/scf.py
@@ -1,0 +1,35 @@
+import numpy as np
+import psi4
+import jk
+
+# Make sure we get the same random array
+np.random.seed(0)
+
+# A hydrogen molecule
+mol = psi4.geometry("""
+O
+H 1 1.1
+H 1 1.1 2 104
+""")
+
+# Build a ERI tensor
+basis = psi4.core.BasisSet.build(mol, target="cc-pVDZ")
+mints = psi4.core.MintsHelper(basis)
+I = np.array(mints.ao_eri())
+
+# Symmetric random density
+nbf = I.shape[0]
+D = np.random.rand(nbf, nbf)
+D = (D + D.T) / 2
+
+# Reference
+J_ref = np.einsum("pqrs,rs->pq", I, D)
+K_ref = np.einsum("prqs,rs->pq", I, D)
+
+# Your implementation
+J = jk.getJ_np(I, D)
+K = jk.getJ_np(np.swapaxes(I, 1, 2), D)
+
+# Make sure your implementation is correct
+print("J is correct: %s" % np.allclose(J, J_ref))
+print("K is correct: %s" % np.allclose(K, K_ref))

--- a/jk/build/scf.py
+++ b/jk/build/scf.py
@@ -14,7 +14,7 @@ H 1 1.1 2 104
 """)
 
 # Build a ERI tensor
-basis = psi4.core.BasisSet.build(mol, target="cc-pVDZ")
+basis = psi4.core.BasisSet.build(mol, target="cc-pvdz")
 mints = psi4.core.MintsHelper(basis)
 I = np.array(mints.ao_eri())
 
@@ -35,11 +35,21 @@ print(end - start)
 start = time.time()
 II = np.swapaxes(I, 1, 2).copy()
 for i in range(1000):
-    J = jk.getJ_np(I, D)
-    K = jk.getJ_np(II, D)
+    J = jk.getJK_np(I, D)
+    K = jk.getJK_np(II, D)
+end = time.time()
+print(end - start)
+
+# Your implementation 2
+start = time.time()
+for i in range(1000):
+    J2 = jk.getJ_np(I, D)
+    K2 = jk.getK_np(II, D)
 end = time.time()
 print(end - start)
 
 # Make sure your implementation is correct
 print("J is correct: %s" % np.allclose(J, J_ref))
 print("K is correct: %s" % np.allclose(K, K_ref))
+print("J2 is correct: %s" % np.allclose(J2, J_ref))
+print("K2 is correct: %s" % np.allclose(K2, K_ref))

--- a/jk/build/scf.py
+++ b/jk/build/scf.py
@@ -1,6 +1,6 @@
 import numpy as np
-import psi4
 import jk
+import psi4
 import time
 
 # Make sure we get the same random array
@@ -14,42 +14,34 @@ H 1 1.1 2 104
 """)
 
 # Build a ERI tensor
-basis = psi4.core.BasisSet.build(mol, target="cc-pvdz")
+basis = psi4.core.BasisSet.build(mol, target="cc-pvqz")
 mints = psi4.core.MintsHelper(basis)
 I = np.array(mints.ao_eri())
+print("nbas = ", I.shape[0])
 
 # Symmetric random density
 nbf = I.shape[0]
 D = np.random.rand(nbf, nbf)
 D = (D + D.T) / 2
 
+n_trials = 1
+
 # Reference
 start = time.time()
-for i in range(1000):
+for i in range(n_trials):
     J_ref = np.einsum("pqrs,rs->pq", I, D)
     K_ref = np.einsum("prqs,rs->pq", I, D)
 end = time.time()
 print(end - start)
 
 # Your implementation
-start = time.time()
 II = np.swapaxes(I, 1, 2).copy()
-for i in range(1000):
-    J = jk.getJK_np(I, D)
-    K = jk.getJK_np(II, D)
-end = time.time()
-print(end - start)
-
-# Your implementation 2
 start = time.time()
-for i in range(1000):
-    J2 = jk.getJ_np(I, D)
-    K2 = jk.getK_np(II, D)
+for i in range(n_trials):
+    J, K = jk.getJK_np(I, I.swapaxes(1, 2).copy(), D)
 end = time.time()
 print(end - start)
 
 # Make sure your implementation is correct
 print("J is correct: %s" % np.allclose(J, J_ref))
 print("K is correct: %s" % np.allclose(K, K_ref))
-print("J2 is correct: %s" % np.allclose(J2, J_ref))
-print("K2 is correct: %s" % np.allclose(K2, K_ref))

--- a/jk/build/scf.py
+++ b/jk/build/scf.py
@@ -1,6 +1,7 @@
 import numpy as np
 import psi4
 import jk
+import time
 
 # Make sure we get the same random array
 np.random.seed(0)
@@ -23,12 +24,21 @@ D = np.random.rand(nbf, nbf)
 D = (D + D.T) / 2
 
 # Reference
-J_ref = np.einsum("pqrs,rs->pq", I, D)
-K_ref = np.einsum("prqs,rs->pq", I, D)
+start = time.time()
+for i in range(1000):
+    J_ref = np.einsum("pqrs,rs->pq", I, D)
+    K_ref = np.einsum("prqs,rs->pq", I, D)
+end = time.time()
+print(end - start)
 
 # Your implementation
-J = jk.getJ_np(I, D)
-K = jk.getJ_np(np.swapaxes(I, 1, 2), D)
+start = time.time()
+II = np.swapaxes(I, 1, 2).copy()
+for i in range(1000):
+    J = jk.getJ_np(I, D)
+    K = jk.getJ_np(II, D)
+end = time.time()
+print(end - start)
 
 # Make sure your implementation is correct
 print("J is correct: %s" % np.allclose(J, J_ref))

--- a/jk/jk.cpp
+++ b/jk/jk.cpp
@@ -1,0 +1,67 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <pybind11/stl.h>
+#include <string>
+#include <iostream>
+
+namespace py = pybind11;
+
+py::array_t<double> getJ_np(py::array_t<double> g,
+                            py::array_t<double> D)
+{
+    py::buffer_info g_info = g.request();
+    py::buffer_info D_info = D.request();
+
+    if(g_info.ndim != 4)
+        throw std::runtime_error("g is not a four-tensor");
+
+    if(D_info.ndim != 2)
+        throw std::runtime_error("D is not a matrix");
+
+    if(g_info.shape[0] != D_info.shape[0])
+        throw std::runtime_error("Dimensions not match");
+
+    size_t nbas = g_info.shape[0];
+    size_t nbas3 = nbas * nbas * nbas;
+    size_t nbas2 = nbas * nbas;
+    size_t s1 = g_info.strides[0] / sizeof(double);
+    size_t s2 = g_info.strides[1] / sizeof(double);
+    size_t s3 = g_info.strides[2] / sizeof(double);
+    size_t s4 = g_info.strides[3] / sizeof(double);
+
+    const double* g_data = static_cast<double*>(g_info.ptr);
+    const double* D_data = static_cast<double*>(D_info.ptr);
+    std::vector<double> J_data(nbas * nbas);
+
+    for(size_t i = 0; i < nbas; i++)
+    for(size_t j = 0; j < nbas; j++)
+    {
+        double val1 = 0., val2 = 0.;
+        for (size_t k = 0; k < nbas; k++)
+        for (size_t l = 0; l < nbas; l++)
+            val1 += g_data[i * s1 + j * s2 + k * s3 + l * s4]
+                * D_data[k * nbas + l];
+        J_data[i * nbas + j] = val1;
+    }
+
+    py::buffer_info J_buf =
+    {
+        J_data.data(),
+        sizeof(double),
+        py::format_descriptor<double>::format(),
+        2,
+        {nbas, nbas},
+        {sizeof(double) * nbas, sizeof(double)}
+    };
+
+    return py::array_t<double>(J_buf);
+}
+
+PYBIND11_PLUGIN(jk)
+{
+    py::module m("jk", "Hongzhou's basic module");
+
+    m.def("getJ_np", &getJ_np, "homemade getJ");
+
+    return m.ptr();
+}

--- a/jk/jk.cpp
+++ b/jk/jk.cpp
@@ -7,7 +7,7 @@
 
 namespace py = pybind11;
 
-py::array_t<double> getJ_np(py::array_t<double> g,
+py::array_t<double> getJK_np(py::array_t<double> g,
                             py::array_t<double> D)
 {
     py::buffer_info g_info = g.request();
@@ -33,9 +33,6 @@ py::array_t<double> getJ_np(py::array_t<double> g,
     const double* g_data = static_cast<double*>(g_info.ptr);
     const double* D_data = static_cast<double*>(D_info.ptr);
     std::vector<double> J_data(nbas * nbas);
-
-    std::vector<double> gvec(nbas * nbas);
-    //std::vector<double> Dvec(nbas * nbas);
 
     for(size_t i = 0; i < nbas; i++)
     for(size_t j = 0; j <= i; j++)
@@ -67,11 +64,120 @@ py::array_t<double> getJ_np(py::array_t<double> g,
     return py::array_t<double>(J_buf);
 }
 
+py::array_t<double> getJ_np(py::array_t<double> g,
+                            py::array_t<double> D)
+{
+    py::buffer_info g_info = g.request();
+    py::buffer_info D_info = D.request();
+
+    if(g_info.ndim != 4)
+        throw std::runtime_error("g is not a four-tensor");
+
+    if(D_info.ndim != 2)
+        throw std::runtime_error("D is not a matrix");
+
+    if(g_info.shape[0] != D_info.shape[0])
+        throw std::runtime_error("Dimensions not match");
+
+    size_t nbas = g_info.shape[0];
+    size_t nbas3 = nbas * nbas * nbas;
+    size_t nbas2 = nbas * nbas;
+    size_t s1 = g_info.strides[0] / sizeof(double);
+    size_t s2 = g_info.strides[1] / sizeof(double);
+    size_t s3 = g_info.strides[2] / sizeof(double);
+    size_t s4 = g_info.strides[3] / sizeof(double);
+
+    const double* g_data = static_cast<double*>(g_info.ptr);
+    const double* D_data = static_cast<double*>(D_info.ptr);
+    std::vector<double> J_data(nbas * nbas);
+
+    for(size_t i = 0; i < nbas; i++)
+    for(size_t j = 0; j <= i; j++)
+    {
+        double val = 0., fac = 0.;
+        int ind = i * s1 + j * s2;
+        for (size_t k = 0; k < nbas; k++)
+        for (size_t l = 0; l <= k; l++)
+        {
+            fac = (k == l) ? (1.) : (2.);
+            val += fac * g_data[ind + k * s3 + l * s4]
+                * D_data[k * nbas + l];
+        }
+        J_data[i * nbas + j] = J_data[j * nbas + i] = val;
+    }
+
+    py::buffer_info J_buf =
+    {
+        J_data.data(),
+        sizeof(double),
+        py::format_descriptor<double>::format(),
+        2,
+        {nbas, nbas},
+        {sizeof(double) * nbas, sizeof(double)}
+    };
+
+    return py::array_t<double>(J_buf);
+}
+
+py::array_t<double> getK_np(py::array_t<double> g,
+                            py::array_t<double> D)
+{
+    py::buffer_info g_info = g.request();
+    py::buffer_info D_info = D.request();
+
+    if(g_info.ndim != 4)
+        throw std::runtime_error("g is not a four-tensor");
+
+    if(D_info.ndim != 2)
+        throw std::runtime_error("D is not a matrix");
+
+    if(g_info.shape[0] != D_info.shape[0])
+        throw std::runtime_error("Dimensions not match");
+
+    size_t nbas = g_info.shape[0];
+    size_t nbas3 = nbas * nbas * nbas;
+    size_t nbas2 = nbas * nbas;
+    size_t s1 = g_info.strides[0] / sizeof(double);
+    size_t s2 = g_info.strides[1] / sizeof(double);
+    size_t s3 = g_info.strides[2] / sizeof(double);
+    size_t s4 = g_info.strides[3] / sizeof(double);
+
+    const double* g_data = static_cast<double*>(g_info.ptr);
+    const double* D_data = static_cast<double*>(D_info.ptr);
+    std::vector<double> J_data(nbas * nbas);
+
+    for(size_t i = 0; i < nbas; i++)
+    for(size_t j = 0; j <= i; j++)
+    {
+        double val = 0., fac = 0.;
+        int ind = i * s1 + j * s2;
+        for (size_t k = 0; k < nbas; k++)
+        for (size_t l = 0; l < nbas; l++)
+            val += g_data[ind + k * s3 + l * s4]
+                * D_data[k * nbas + l];
+        J_data[i * nbas + j] = J_data[j * nbas + i] = val;
+    }
+
+    py::buffer_info J_buf =
+    {
+        J_data.data(),
+        sizeof(double),
+        py::format_descriptor<double>::format(),
+        2,
+        {nbas, nbas},
+        {sizeof(double) * nbas, sizeof(double)}
+    };
+
+    return py::array_t<double>(J_buf);
+}
+
 PYBIND11_PLUGIN(jk)
 {
     py::module m("jk", "Hongzhou's basic module");
 
-    m.def("getJ_np", &getJ_np, "homemade getJ");
+    m.def("getJK_np", &getJK_np, "homemade get J and K");
+    m.def("getJ_np", &getJ_np, "homemade get J");
+    m.def("getK_np", &getK_np, "homemade get K");
 
     return m.ptr();
 }

--- a/jk/jk.cpp
+++ b/jk/jk.cpp
@@ -1,6 +1,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 #include <pybind11/stl.h>
+#include <lawrap/blas.h>
 #include <string>
 #include <iostream>
 
@@ -33,15 +34,24 @@ py::array_t<double> getJ_np(py::array_t<double> g,
     const double* D_data = static_cast<double*>(D_info.ptr);
     std::vector<double> J_data(nbas * nbas);
 
+    std::vector<double> gvec(nbas * nbas);
+    //std::vector<double> Dvec(nbas * nbas);
+
     for(size_t i = 0; i < nbas; i++)
-    for(size_t j = 0; j < nbas; j++)
+    for(size_t j = 0; j <= i; j++)
     {
-        double val1 = 0., val2 = 0.;
+        double val = LAWrap::dot(nbas * nbas, D_data, 1,
+            &g_data[i * s1 + j * s2], 1);
+        /*double val = 0.;
+        int ind = i * s1 + j * s2;
         for (size_t k = 0; k < nbas; k++)
-        for (size_t l = 0; l < nbas; l++)
-            val1 += g_data[i * s1 + j * s2 + k * s3 + l * s4]
+        for (size_t l = 0; l <= k; l++)
+        {
+            double fac = (k == l) ? (1.) : (2.);
+            val += fac * g_data[ind + k * s3 + l * s4]
                 * D_data[k * nbas + l];
-        J_data[i * nbas + j] = val1;
+        }*/
+        J_data[i * nbas + j] = J_data[j * nbas + i] = val;
     }
 
     py::buffer_info J_buf =

--- a/jk/jk.cpp
+++ b/jk/jk.cpp
@@ -7,10 +7,12 @@
 
 namespace py = pybind11;
 
-py::array_t<double> getJK_np(py::array_t<double> g,
-                            py::array_t<double> D)
+py::tuple getJK_np(py::array_t<double> g,
+                  py::array_t<double> gg,
+                  py::array_t<double> D)
 {
     py::buffer_info g_info = g.request();
+    py::buffer_info gg_info = gg.request();
     py::buffer_info D_info = D.request();
 
     if(g_info.ndim != 4)
@@ -23,32 +25,26 @@ py::array_t<double> getJK_np(py::array_t<double> g,
         throw std::runtime_error("Dimensions not match");
 
     size_t nbas = g_info.shape[0];
-    size_t nbas3 = nbas * nbas * nbas;
-    size_t nbas2 = nbas * nbas;
     size_t s1 = g_info.strides[0] / sizeof(double);
     size_t s2 = g_info.strides[1] / sizeof(double);
     size_t s3 = g_info.strides[2] / sizeof(double);
     size_t s4 = g_info.strides[3] / sizeof(double);
 
     const double* g_data = static_cast<double*>(g_info.ptr);
+    const double* gg_data = static_cast<double*>(gg_info.ptr);
     const double* D_data = static_cast<double*>(D_info.ptr);
     std::vector<double> J_data(nbas * nbas);
+    std::vector<double> K_data(nbas * nbas);
 
     for(size_t i = 0; i < nbas; i++)
     for(size_t j = 0; j <= i; j++)
     {
-        double val = LAWrap::dot(nbas * nbas, D_data, 1,
+        double valJ = LAWrap::dot(nbas * nbas, D_data, 1,
             &g_data[i * s1 + j * s2], 1);
-        /*double val = 0.;
-        int ind = i * s1 + j * s2;
-        for (size_t k = 0; k < nbas; k++)
-        for (size_t l = 0; l <= k; l++)
-        {
-            double fac = (k == l) ? (1.) : (2.);
-            val += fac * g_data[ind + k * s3 + l * s4]
-                * D_data[k * nbas + l];
-        }*/
-        J_data[i * nbas + j] = J_data[j * nbas + i] = val;
+        double valK = LAWrap::dot(nbas * nbas, D_data, 1,
+            &gg_data[i * s1 + j * s2], 1);
+        J_data[i * nbas + j] = J_data[j * nbas + i] = valJ;
+        K_data[i * nbas + j] = K_data[j * nbas + i] = valK;
     }
 
     py::buffer_info J_buf =
@@ -60,12 +56,22 @@ py::array_t<double> getJK_np(py::array_t<double> g,
         {nbas, nbas},
         {sizeof(double) * nbas, sizeof(double)}
     };
+    py::buffer_info K_buf =
+    {
+        K_data.data(),
+        sizeof(double),
+        py::format_descriptor<double>::format(),
+        2,
+        {nbas, nbas},
+        {sizeof(double) * nbas, sizeof(double)}
+    };
 
-    return py::array_t<double>(J_buf);
+    return py::make_tuple(py::array_t<double>(J_buf),
+                          py::array_t<double>(K_buf));
 }
 
-py::array_t<double> getJ_np(py::array_t<double> g,
-                            py::array_t<double> D)
+py::tuple getJK_np_Dshift(py::array_t<double> g,
+                          py::array_t<double> D)
 {
     py::buffer_info g_info = g.request();
     py::buffer_info D_info = D.request();
@@ -80,8 +86,6 @@ py::array_t<double> getJ_np(py::array_t<double> g,
         throw std::runtime_error("Dimensions not match");
 
     size_t nbas = g_info.shape[0];
-    size_t nbas3 = nbas * nbas * nbas;
-    size_t nbas2 = nbas * nbas;
     size_t s1 = g_info.strides[0] / sizeof(double);
     size_t s2 = g_info.strides[1] / sizeof(double);
     size_t s3 = g_info.strides[2] / sizeof(double);
@@ -90,20 +94,22 @@ py::array_t<double> getJ_np(py::array_t<double> g,
     const double* g_data = static_cast<double*>(g_info.ptr);
     const double* D_data = static_cast<double*>(D_info.ptr);
     std::vector<double> J_data(nbas * nbas);
+    std::vector<double> K_data(nbas * nbas);
 
     for(size_t i = 0; i < nbas; i++)
     for(size_t j = 0; j <= i; j++)
     {
-        double val = 0., fac = 0.;
-        int ind = i * s1 + j * s2;
-        for (size_t k = 0; k < nbas; k++)
-        for (size_t l = 0; l <= k; l++)
+        double valJ = 0., valK = 0.;
+        int indJ = i * s1 + j * s2, indK = i * s1 + j * s3;
+        for(size_t k = 0; k < nbas; k++)
+        for(size_t l = 0; l <= k; l++)
         {
-            fac = (k == l) ? (1.) : (2.);
-            val += fac * g_data[ind + k * s3 + l * s4]
-                * D_data[k * nbas + l];
+            valJ += 2. * g_data[indJ + k * s3 + l * s4] * D_data[k * nbas + l];
+            valK += (g_data[indK + k * s2 + l * s4] +
+                g_data[indK + k * s4 + l * s2]) * D_data[k * nbas + l];
         }
-        J_data[i * nbas + j] = J_data[j * nbas + i] = val;
+        J_data[i * nbas + j] = J_data[j * nbas + i] = valJ;
+        K_data[i * nbas + j] = K_data[j * nbas + i] = valK;
     }
 
     py::buffer_info J_buf =
@@ -115,52 +121,9 @@ py::array_t<double> getJ_np(py::array_t<double> g,
         {nbas, nbas},
         {sizeof(double) * nbas, sizeof(double)}
     };
-
-    return py::array_t<double>(J_buf);
-}
-
-py::array_t<double> getK_np(py::array_t<double> g,
-                            py::array_t<double> D)
-{
-    py::buffer_info g_info = g.request();
-    py::buffer_info D_info = D.request();
-
-    if(g_info.ndim != 4)
-        throw std::runtime_error("g is not a four-tensor");
-
-    if(D_info.ndim != 2)
-        throw std::runtime_error("D is not a matrix");
-
-    if(g_info.shape[0] != D_info.shape[0])
-        throw std::runtime_error("Dimensions not match");
-
-    size_t nbas = g_info.shape[0];
-    size_t nbas3 = nbas * nbas * nbas;
-    size_t nbas2 = nbas * nbas;
-    size_t s1 = g_info.strides[0] / sizeof(double);
-    size_t s2 = g_info.strides[1] / sizeof(double);
-    size_t s3 = g_info.strides[2] / sizeof(double);
-    size_t s4 = g_info.strides[3] / sizeof(double);
-
-    const double* g_data = static_cast<double*>(g_info.ptr);
-    const double* D_data = static_cast<double*>(D_info.ptr);
-    std::vector<double> J_data(nbas * nbas);
-
-    for(size_t i = 0; i < nbas; i++)
-    for(size_t j = 0; j <= i; j++)
+    py::buffer_info K_buf =
     {
-        double val = 0., fac = 0.;
-        int ind = i * s1 + j * s2;
-        for (size_t k = 0; k < nbas; k++)
-        for (size_t l = 0; l < nbas; l++)
-            val += g_data[ind + k * s3 + l * s4]
-                * D_data[k * nbas + l];
-        J_data[i * nbas + j] = J_data[j * nbas + i] = val;
-    }
-
-    py::buffer_info J_buf =
-    {
-        J_data.data(),
+        K_data.data(),
         sizeof(double),
         py::format_descriptor<double>::format(),
         2,
@@ -168,16 +131,17 @@ py::array_t<double> getK_np(py::array_t<double> g,
         {sizeof(double) * nbas, sizeof(double)}
     };
 
-    return py::array_t<double>(J_buf);
+    return py::make_tuple(py::array_t<double>(J_buf),
+                          py::array_t<double>(K_buf));
 }
 
 PYBIND11_PLUGIN(jk)
 {
     py::module m("jk", "Hongzhou's basic module");
 
-    m.def("getJK_np", &getJK_np, "homemade get J and K");
-    m.def("getJ_np", &getJ_np, "homemade get J");
-    m.def("getK_np", &getK_np, "homemade get K");
+    m.def("getJK_np", &getJK_np, "homemade get J and K (returned as a tuple)");
+    m.def("getJK_np_Dshift", &getJK_np_Dshift,
+        "homemade get J and K (returned as a tuple) w/ np.diag(D) shifted");
 
     return m.ptr();
 }

--- a/scf/scf_utils.py
+++ b/scf/scf_utils.py
@@ -3,6 +3,7 @@ import os, sys
 sys.path.append(os.path.dirname(__file__))
 from diis_solver import diis_solver
 sys.path.pop()
+import jk
 
 
 def get_dm(C, nel):
@@ -20,8 +21,9 @@ def get_JK(is_fitted, g, D):
         K = np.einsum('mlP,Pnl->mn', np.swapaxes(g, 0, 2), Z)
         return (J, K)
     else:
-        J = np.einsum("pqrs,rs->pq", g, D)
-        K = np.einsum("prqs,rs->pq", g, D)
+        #J = np.einsum("pqrs,rs->pq", g, D)
+        #K = np.einsum("prqs,rs->pq", g, D)
+        J, K = jk.getJK_np_Dshift(g, D - np.diag(np.diag(D) * 0.5))
         return (J, K)
 
 


### PR DESCRIPTION
I made `jk` a module and added it to `scf_utils.py`.
The algorithm I used is an optimized version of what's been used in Team 7's code.
The speed up over `np.einsum` on `cc-pVQZ` basis set for water is 190ms / 140ms ~ 1.3 times.